### PR TITLE
Static nested classes in Kotlin

### DIFF
--- a/src/main/groovy/com/javagen/schema/kotlin/KotlinEmitter.groovy
+++ b/src/main/groovy/com/javagen/schema/kotlin/KotlinEmitter.groovy
@@ -82,8 +82,8 @@ class KotlinEmitter extends CodeEmitter
 		out << '\n' << tabs
 		if (c.scope && c.scope != 'public')
 			out << c.scope << ' '
-		if (c.isStatic())
-			out << 'static '
+		if (!c.isStatic())
+			out << 'inner '
 		if (c.isAbstract())
 			out << 'abstract '
 		if (c.data)


### PR DESCRIPTION
Nested classes in Kotlin are static by default; to have non-static nested classes, the 'inner' keyword must be applied.

Fixes issue #14